### PR TITLE
Expect x and y relative to viewport

### DIFF
--- a/dist/nearest-schnellaaa.js
+++ b/dist/nearest-schnellaaa.js
@@ -1,10 +1,10 @@
 /*!
 * nearest-schnellaaa - jQuery plugin to find filter a selection of elements to only those near a certain point
-* v0.0.1 - 2014-08-02 1:01:21 PM UTC
+* v0.0.2 - 2014-08-03 8:45:36 AM UTC
 * Copyright (c) 2014 timse; Licensed 
 */
  ;(function($){
-;var $win, ensureListeners, filterFn, noop, resizeListener, scrollLeft, scrollListener, scrollTop, throttle, viewportHeight, viewportWidth;
+;var $win, ensureListeners, filterFn, noop, resizeListener, throttle, viewportHeight, viewportWidth;
 
 $win = $(window);
 
@@ -26,19 +26,12 @@ throttle = function(fn, wait) {
   };
 };
 
-viewportHeight = viewportWidth = scrollTop = scrollLeft = null;
-
-scrollListener = function() {
-  scrollTop = $win.scrollTop();
-  scrollLeft = $win.scrollLeft();
-};
+viewportHeight = viewportWidth = null;
 
 resizeListener = function() {
   viewportWidth = $win.width();
   viewportHeight = $win.height();
 };
-
-scrollListener();
 
 resizeListener();
 
@@ -46,7 +39,7 @@ noop = function() {};
 
 ensureListeners = function() {
   ensureListeners = noop;
-  $win.on('scroll', throttle(scrollListener, 50)).on('resize', throttle(resizeListener, 50));
+  $win.on('resize', throttle(resizeListener, 50));
 };
 
 filterFn = function(left, right, top, bottom, elem) {
@@ -76,8 +69,6 @@ filterFn = function(left, right, top, bottom, elem) {
 $.fn['nearest-schnellaaa'] = $.fn['nearestSchnellaaa'] = function(x, y, prox) {
   var bottom, elem, left, res, right, top, _i, _len;
   ensureListeners();
-  x -= scrollLeft;
-  y -= scrollTop;
   left = x - prox;
   top = y - prox;
   right = x + prox;

--- a/dist/nearest-schnellaaa.min.js
+++ b/dist/nearest-schnellaaa.min.js
@@ -1,6 +1,6 @@
 /*!
 * nearest-schnellaaa - jQuery plugin to find filter a selection of elements to only those near a certain point
-* v0.0.1 - 2014-08-02 1:01:21 PM UTC
+* v0.0.2 - 2014-08-03 8:45:36 AM UTC
 * Copyright (c) 2014 timse; Licensed 
 */
-!function(a){var b,c,d,e,f,g,h,i,j,k,l;b=a(window),j=function(a,b){var c,d,e;return c=null,e=null,d=function(){var f,g;return g=+new Date,f=g-c,!c||f>b?(c=g,a()):(clearTimeout(e),e=setTimeout(d,b-f+1))}},k=l=i=g=null,h=function(){i=b.scrollTop(),g=b.scrollLeft()},f=function(){l=b.width(),k=b.height()},h(),f(),e=function(){},c=function(){c=e,b.on("scroll",j(h,50)).on("resize",j(f,50))},d=function(a,b,c,d,e){var f;return f=e.getBoundingClientRect(),f.bottom<0?!1:f.top>k?!1:f.right<a?!1:f.left>b?!1:f.bottom<c?!1:f.top>d?!1:!0},a.fn["nearest-schnellaaa"]=a.fn.nearestSchnellaaa=function(b,e,f){var h,j,k,l,m,n,o,p;for(c(),b-=g,e-=i,k=b-f,n=e-f,m=b+f,h=e+f,l=[],o=0,p=this.length;p>o;o++)j=this[o],d(k,n,m,h,j)&&l.push(j);return a(l)}}(window.jQuery);
+!function(a){var b,c,d,e,f,g,h,i;b=a(window),g=function(a,b){var c,d,e;return c=null,e=null,d=function(){var f,g;return g=+new Date,f=g-c,!c||f>b?(c=g,a()):(clearTimeout(e),e=setTimeout(d,b-f+1))}},h=i=null,f=function(){i=b.width(),h=b.height()},f(),e=function(){},c=function(){c=e,b.on("resize",g(f,50))},d=function(a,b,c,d,e){var f;return f=e.getBoundingClientRect(),f.bottom<0?!1:f.top>h?!1:f.right<a?!1:f.left>b?!1:f.bottom<c?!1:f.top>d?!1:!0},a.fn["nearest-schnellaaa"]=a.fn.nearestSchnellaaa=function(b,e,f){var g,h,i,j,k,l,m,n;for(c(),i=b-f,l=e-f,k=b+f,g=e+f,j=[],m=0,n=this.length;n>m;m++)h=this[m],d(i,l,k,g,h)&&j.push(h);return a(j)}}(window.jQuery);

--- a/src/nearest-schnellaaa.coffee
+++ b/src/nearest-schnellaaa.coffee
@@ -16,26 +16,20 @@
 
 
 
-    viewportHeight = viewportWidth = scrollTop = scrollLeft = null
+    viewportHeight = viewportWidth = null
 
-    scrollListener = ->
-        scrollTop = $win.scrollTop()
-        scrollLeft = $win.scrollLeft()
-        return
     resizeListener = ->
         viewportWidth = $win.width()
         viewportHeight = $win.height()
         return
 
     #set values initially
-    scrollListener()
     resizeListener()
 
     noop = ->
     ensureListeners = ->
         ensureListeners = noop
-        $win.on 'scroll', throttle scrollListener, 50
-        .on 'resize', throttle resizeListener, 50
+        $win.on 'resize', throttle resizeListener, 50
         return
 
     filterFn = (left, right, top, bottom, elem)->
@@ -71,12 +65,6 @@
 
     $.fn['nearest-schnellaaa'] = $.fn['nearestSchnellaaa'] = (x, y, prox)->
         ensureListeners()
-
-        # expecting absolute x, y but calculating in relative dimensions
-        # thus we need to substract the scrollings from the point
-
-        x -= scrollLeft
-        y -= scrollTop
 
         left = x - prox
         top = y - prox

--- a/src/nearest-schnellaaa.js
+++ b/src/nearest-schnellaaa.js
@@ -1,4 +1,4 @@
-var $win, ensureListeners, filterFn, noop, resizeListener, scrollLeft, scrollListener, scrollTop, throttle, viewportHeight, viewportWidth;
+var $win, ensureListeners, filterFn, noop, resizeListener, throttle, viewportHeight, viewportWidth;
 
 $win = $(window);
 
@@ -20,19 +20,12 @@ throttle = function(fn, wait) {
   };
 };
 
-viewportHeight = viewportWidth = scrollTop = scrollLeft = null;
-
-scrollListener = function() {
-  scrollTop = $win.scrollTop();
-  scrollLeft = $win.scrollLeft();
-};
+viewportHeight = viewportWidth = null;
 
 resizeListener = function() {
   viewportWidth = $win.width();
   viewportHeight = $win.height();
 };
-
-scrollListener();
 
 resizeListener();
 
@@ -40,7 +33,7 @@ noop = function() {};
 
 ensureListeners = function() {
   ensureListeners = noop;
-  $win.on('scroll', throttle(scrollListener, 50)).on('resize', throttle(resizeListener, 50));
+  $win.on('resize', throttle(resizeListener, 50));
 };
 
 filterFn = function(left, right, top, bottom, elem) {
@@ -70,8 +63,6 @@ filterFn = function(left, right, top, bottom, elem) {
 $.fn['nearest-schnellaaa'] = $.fn['nearestSchnellaaa'] = function(x, y, prox) {
   var bottom, elem, left, res, right, top, _i, _len;
   ensureListeners();
-  x -= scrollLeft;
-  y -= scrollTop;
   left = x - prox;
   top = y - prox;
   right = x + prox;

--- a/test/nearest-schnellaaa.coffee
+++ b/test/nearest-schnellaaa.coffee
@@ -5,22 +5,10 @@ describe "nearest-schnellaaa", ->
 
     describe "helpers like event listeners", ->
 
-        describe "viewportHeight, viewportWidth, scrollTop, and scrollLeft", ->
+        describe "viewportHeight and viewportWidth", ->
             it 'they should all initially be set', ->
-                scrollLeft.should.be.a.number
-                scrollTop.should.be.a.number
                 viewportWidth.should.be.a.number
                 viewportHeight.should.be.a.number
-
-        describe "scrollListener", ->
-
-            it 'should set the variables scrollTop and scrollLeft', ->
-                window.scrollLeft = window.scrollTop = null
-
-                scrollListener()
-
-                scrollLeft.should.be.a.number
-                scrollTop.should.be.a.number
 
         describe "resizeListener", ->
             it 'should set the variables viewportHeight and viewportWidth', ->
@@ -54,11 +42,11 @@ describe "nearest-schnellaaa", ->
                     done()
                 , 55
         describe "ensureListeners", ->
-            it 'should set the event listeners for scrolling and resize on the window if called', ->
+            it 'should set the event listeners for resize on the window if called', ->
                 sinon.stub(jQuery.fn, 'on').returns($win)
 
                 ensureListeners()
-                $win.on.should.be.calledTwice
+                $win.on.should.be.calledOnce
 
                 $win.on.restore()
 


### PR DESCRIPTION
Since event.clientX and eventclientY contain exactly the information we need 
( and are highly x-browser compatible [http://quirksmode.org/mobile/tableViewport_desktop.html#t10](http://quirksmode.org/mobile/tableViewport_desktop.html#t10) )
we dont need to have a expensive scroll listener after all
